### PR TITLE
Do not check if LND is used on uncompatible coins

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -132,16 +132,6 @@ $(document).ready(function() {
 	}
 
 	function validateStep3() {
-		// LND can only be used with BTC and LTC
-		var unsupportedCoins = getCheckedCoins().filter(function(el) {
-			return el != 'btc' && el != 'ltc';
-		});
-		var lndEnabled = $('#lightning').val() === 'lnd';
-		if(unsupportedCoins.length > 0 && lndEnabled) {
-			showError('LND can only be used with BTC and LTC');
-			return false;
-		}
-
 		showError();
 		return true;
 	}


### PR DESCRIPTION
Ping @bitcoinshirt for ACK. 

If we later add support to LND to some now unsupported coins, we should not have to update this repo.
Also somebody might want say BTC+LTC+FTC with LND only for BTC+LTC, and not care that it is not available with FTC.