### PR TITLE
Remove creation of SSH keys for BTCPay Server

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -91,13 +91,6 @@ for coin in coins:
 		env['BTCPAYGEN_CRYPTO{}'.format(crypto_counter)] = coin
 		crypto_counter += 1
 
-# create SSH key
-subprocess.call(['ssh-keygen', '-t', 'rsa', '-f', '/root/.ssh/id_rsa_btcpay', '-q', '-P', '', '-m', 'PEM'])
-with open('/root/.ssh/id_rsa_btcpay.pub', 'r') as f:
-	btcpay_sshkey = f.read()
-with open('/root/.ssh/authorized_keys', 'a') as f:
-	f.write(btcpay_sshkey)
-
 env['BTCPAY_HOST'] = hostname
 env['NBITCOIN_NETWORK'] = network
 env['LETSENCRYPT_EMAIL'] = email
@@ -107,7 +100,6 @@ env['BTCPAYGEN_LIGHTNING'] = lightning
 env['LIGHTNING_ALIAS'] = alias
 env['BTCPAYGEN_ADDITIONAL_FRAGMENTS'] = 'opt-save-storage-s'
 env['BTCPAY_ENABLE_SSH'] = 'true'
-env['BTCPAY_HOST_SSHKEYFILE'] = '/root/.ssh/id_rsa_btcpay'
 
 for i in range(5):
 	popen = subprocess.Popen(


### PR DESCRIPTION
Setting `BTCPAY_ENABLE_SSH=true`  is enough for BTCPay to get access to the underlying VM.
The explicit creation of SSH key is an artifact no longer relevant.

That said, I am surprised that this commit https://github.com/LunaNode/launchbtcpay/commit/949dd49e81c004f559a4f2763ea984d668d215ba has been done after `BTCPAY_ENABLE_SSH` start existing @uakfdotb would you remember why by any chance? It should never have been needed in the first place.

The easy way to see if things are working as expected is: 

* Create a VM
* Go to https://domain.blah/server/maintenance
* Click on Update and see if it errors or not

Note that the current settings works, but I am worried about it, as I was not expecting `BTCPAY_HOST_SSHKEYFILE` to be set.